### PR TITLE
Use the correct takeDamage

### DIFF
--- a/ARcade/Game/GameActionHandling/GameManager.swift
+++ b/ARcade/Game/GameActionHandling/GameManager.swift
@@ -138,7 +138,7 @@ class GameManager{
             }
             break
         case .playerShootMultiTakedown:
-            if aliens[action.targetID]!.takeDamage(from: action.sourceID) == GameActor.lifeState.dead {
+            if aliens[action.targetID]!.takeDamage(fromPlayerNumber: action.sourceID) == GameActor.lifeState.dead {
                 aliens[action.targetID]!.node!.removeFromParentNode()
                 aliens[action.targetID] = nil
             }

--- a/ARcade/Game/GameEntities/Aliens/Alien.swift
+++ b/ARcade/Game/GameEntities/Aliens/Alien.swift
@@ -47,6 +47,7 @@ class Alien: GameActor {
     }
     
     func takeDamage(fromPlayerNumber playerNumber: Int) -> GameActor.lifeState {
+        /// Specific implementation for MultiTakeDownType alien
         if (!listOfIdentifiers.contains(playerNumber)){
             listOfIdentifiers.append(playerNumber)
         }


### PR DESCRIPTION
The game manager was still using the takeDamage function of the GameActor when it needs to use the overwritten takeDamage function in the Alien class made specifically for the MultiTakeDown type of alien.